### PR TITLE
feat: add performance metrics to CLI output

### DIFF
--- a/src/bin/birdnet-analyze.rs
+++ b/src/bin/birdnet-analyze.rs
@@ -399,10 +399,11 @@ fn run_with_args(args: Args) -> Result<()> {
     #[allow(clippy::cast_precision_loss)]
     let segments_per_sec = segment_count as f32 / elapsed_secs;
     let audio_secs_per_sec = duration_secs / elapsed_secs;
+    let audio_duration = format_duration(duration_secs);
 
     println!();
     println!(
-        "{segment_count} segments analyzed in {elapsed_secs:.1}s ({segments_per_sec:.1} segments/s, {audio_secs_per_sec:.1}x realtime)"
+        "{segment_count} segments of {audio_duration} audio analyzed in {elapsed_secs:.1}s ({segments_per_sec:.1} segments/s, {audio_secs_per_sec:.1}x realtime)"
     );
 
     Ok(())
@@ -514,13 +515,17 @@ fn format_time(secs: f32) -> String {
     format!("{mins:02}:{secs_part:04.1}")
 }
 
-/// Format duration as `XmYs`.
+/// Format duration as human-readable string (e.g., "45s", "3m 23s", "1h 15m 30s").
 fn format_duration(secs: f32) -> String {
     #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
     let total_secs = secs as u32;
-    let mins = total_secs / 60;
+    let hours = total_secs / 3600;
+    let mins = (total_secs % 3600) / 60;
     let secs_part = total_secs % 60;
-    if mins > 0 {
+
+    if hours > 0 {
+        format!("{hours}h {mins}m {secs_part}s")
+    } else if mins > 0 {
         format!("{mins}m {secs_part}s")
     } else {
         format!("{secs_part}s")


### PR DESCRIPTION
## Summary
- Add segments per second metric to CLI output
- Add realtime processing speed multiplier (e.g., 10.5x realtime)
- Example output: `42 segments analyzed in 2.3s (18.3 segments/s, 10.5x realtime)`

## Purpose
This CLI tool serves as a debug tool for the library, and performance metrics are essential for:
- Benchmarking different execution providers (CPU, CUDA, TensorRT, etc.)
- Identifying processing bottlenecks
- Evaluating hardware acceleration effectiveness

## Test Plan
- [x] All existing tests pass
- [x] Clippy lints pass
- [x] Code formatting verified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced the analysis summary to report processing metrics: elapsed time, segments/sec, and audio-secs/sec alongside segment count.
  * Improved audio duration display to a human-friendly format (hours, minutes, seconds) in the final summary output.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->