### PR TITLE
Fix range filter allowing out-of-range species through

### DIFF
--- a/src/rangefilter.rs
+++ b/src/rangefilter.rs
@@ -366,12 +366,8 @@ fn filter_predictions_impl(
                     None
                 }
                 None => {
-                    // Species NOT in meta model: keep unchanged
-                    Some(Prediction {
-                        species: pred.species.clone(),
-                        confidence: pred.confidence,
-                        index: pred.index,
-                    })
+                    // Species NOT in meta model: filter out (not expected at this location)
+                    None
                 }
             }
         })
@@ -852,15 +848,11 @@ mod tests {
         let filtered = filter_predictions_impl(&predictions, &location_scores, threshold, rerank);
 
         // Species A (in meta, score >= threshold): KEEP
-        // Species B (NOT in meta model): KEEP unchanged
-        // Species D (NOT in meta model): KEEP unchanged
-        assert_eq!(filtered.len(), 3);
+        // Species B (NOT in meta model): FILTER OUT (not expected at location)
+        // Species D (NOT in meta model): FILTER OUT (not expected at location)
+        assert_eq!(filtered.len(), 1);
         assert_eq!(filtered[0].species, "Species A");
         assert_eq!(filtered[0].confidence, 0.8);
-        assert_eq!(filtered[1].species, "Species B");
-        assert_eq!(filtered[1].confidence, 0.7);
-        assert_eq!(filtered[2].species, "Species D");
-        assert_eq!(filtered[2].confidence, 0.9);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Species not found in the meta model's location scores were incorrectly kept in detection results instead of being filtered out
- This caused out-of-range species (e.g., North American *Certhia americana*, *Regulus satrapa*) to appear in detections for locations where they don't occur (e.g., lat=62.13, lon=25.67 in Finland)
- The `None` branch in `filter_predictions_impl()` now correctly filters these species out

## Test plan

- [x] Unit tests updated and passing (`test_filter_predictions_species_not_in_meta_model` now asserts species absent from location scores are filtered out)
- [ ] Manual test: run `birda --lat 62.13 --lon 25.67 --week 15` on audio file and verify no North American species in results

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prediction filtering to exclude species not supported by the current location model, ensuring only validated predictions are displayed to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->