### PR TITLE
fix: resolve BirdNET v3.0 ONNX outputs by name, not by position

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "birdnet-onnx"
-version = "2.0.0-rc.15"
+version = "2.0.0-rc.16"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "birdnet-onnx"
-version = "2.0.0-rc.15"
+version = "2.0.0-rc.16"
 edition = "2024"
 rust-version = "1.92"
 description = "Bird species detection using BirdNET, Perch, and BSG Finland ONNX models"

--- a/src/batch_context.rs
+++ b/src/batch_context.rs
@@ -275,12 +275,11 @@ impl BatchInferenceContext {
                     })?;
             }
             ModelType::BirdNetV24 | ModelType::BsgFinland => {
-                let output_name = self
-                    .output_names
-                    .first()
-                    .ok_or_else(|| Error::Inference("model has no output tensors".to_string()))?;
+                // Cloned so the borrow of `self.output_names` ends before
+                // `self.io_binding` is borrowed mutably.
+                let output_name = self.predictions_output_name()?.to_string();
                 self.io_binding
-                    .bind_output_to_device(output_name, &mem_info)
+                    .bind_output_to_device(&output_name, &mem_info)
                     .map_err(|e| Error::Inference(format!("failed to bind output: {e}")))?;
             }
             ModelType::BirdNetV30 => {

--- a/src/batch_context.rs
+++ b/src/batch_context.rs
@@ -261,17 +261,15 @@ impl BatchInferenceContext {
 
         match self.model_type {
             ModelType::BirdNetV24 if self.embedding_dim.is_some() => {
-                let output_0 = self.output_names.first().ok_or_else(|| {
-                    Error::Inference("model missing first output tensor".to_string())
-                })?;
-                let output_1 = self.output_names.get(1).ok_or_else(|| {
-                    Error::Inference("model missing second output tensor".to_string())
-                })?;
+                // Cloned so the borrow of `self.output_names` ends before
+                // `self.io_binding` is borrowed mutably below.
+                let logits_name = self.predictions_output_name()?.to_string();
+                let embeddings_name = self.embeddings_output_name()?.to_string();
                 self.io_binding
-                    .bind_output_to_device(output_0, &mem_info)
+                    .bind_output_to_device(&logits_name, &mem_info)
                     .map_err(|e| Error::Inference(format!("failed to bind logits output: {e}")))?;
                 self.io_binding
-                    .bind_output_to_device(output_1, &mem_info)
+                    .bind_output_to_device(&embeddings_name, &mem_info)
                     .map_err(|e| {
                         Error::Inference(format!("failed to bind embeddings output: {e}"))
                     })?;
@@ -338,25 +336,24 @@ impl BatchInferenceContext {
                 let embedding_dim = self.embedding_dim.ok_or_else(|| {
                     Error::Inference("embedding_dim required for v2.4 with embeddings".into())
                 })?;
-                let output_0 = self.output_names.first().ok_or_else(|| {
-                    Error::Inference("model missing first output tensor".to_string())
-                })?;
-                let output_1 = self.output_names.get(1).ok_or_else(|| {
-                    Error::Inference("model missing second output tensor".to_string())
-                })?;
-                let logits =
-                    Self::extract_tensor_data(outputs, output_0, batch_size * self.num_species)?;
-                let embeddings =
-                    Self::extract_tensor_data(outputs, output_1, batch_size * embedding_dim)?;
+                let logits = Self::extract_tensor_data(
+                    outputs,
+                    self.predictions_output_name()?,
+                    batch_size * self.num_species,
+                )?;
+                let embeddings = Self::extract_tensor_data(
+                    outputs,
+                    self.embeddings_output_name()?,
+                    batch_size * embedding_dim,
+                )?;
                 Ok((Some(embeddings), logits))
             }
             ModelType::BirdNetV24 | ModelType::BsgFinland => {
-                let output_name = self
-                    .output_names
-                    .first()
-                    .ok_or_else(|| Error::Inference("model has no output tensors".to_string()))?;
-                let logits =
-                    Self::extract_tensor_data(outputs, output_name, batch_size * self.num_species)?;
+                let logits = Self::extract_tensor_data(
+                    outputs,
+                    self.predictions_output_name()?,
+                    batch_size * self.num_species,
+                )?;
                 Ok((None, logits))
             }
             ModelType::BirdNetV30 => {

--- a/src/batch_context.rs
+++ b/src/batch_context.rs
@@ -85,6 +85,10 @@ pub struct BatchInferenceContext {
     model_type: ModelType,
     /// Output tensor names from the model
     output_names: Vec<String>,
+    /// Index of the class-score output, resolved during detection.
+    predictions_index: usize,
+    /// Index of the embeddings output, resolved during detection.
+    embeddings_index: Option<usize>,
 }
 
 impl BatchInferenceContext {
@@ -140,6 +144,8 @@ impl BatchInferenceContext {
             embedding_dim: config.embedding_dim,
             model_type: config.model_type,
             output_names,
+            predictions_index: config.predictions_index,
+            embeddings_index: config.embeddings_index,
         })
     }
 
@@ -280,20 +286,20 @@ impl BatchInferenceContext {
                     .map_err(|e| Error::Inference(format!("failed to bind output: {e}")))?;
             }
             ModelType::BirdNetV30 => {
-                // Two outputs: embeddings and logits
-                let output_0 = self.output_names.first().ok_or_else(|| {
-                    Error::Inference("model missing first output tensor".to_string())
-                })?;
-                let output_1 = self.output_names.get(1).ok_or_else(|| {
-                    Error::Inference("model missing second output tensor".to_string())
-                })?;
+                // Bound by resolved role rather than by position. Binding both
+                // is what matters here, but naming them correctly keeps the
+                // error messages honest when one is missing.
+                // Cloned so the borrow of `self.output_names` ends before
+                // `self.io_binding` is borrowed mutably below.
+                let embeddings_name = self.embeddings_output_name()?.to_string();
+                let logits_name = self.predictions_output_name()?.to_string();
                 self.io_binding
-                    .bind_output_to_device(output_0, &mem_info)
+                    .bind_output_to_device(&embeddings_name, &mem_info)
                     .map_err(|e| {
                         Error::Inference(format!("failed to bind embeddings output: {e}"))
                     })?;
                 self.io_binding
-                    .bind_output_to_device(output_1, &mem_info)
+                    .bind_output_to_device(&logits_name, &mem_info)
                     .map_err(|e| Error::Inference(format!("failed to bind logits output: {e}")))?;
             }
             ModelType::PerchV2 => {
@@ -357,20 +363,47 @@ impl BatchInferenceContext {
                 let embedding_dim = self.embedding_dim.ok_or_else(|| {
                     Error::Inference("embedding_dim required for BirdNetV30".into())
                 })?;
-                let output_0 = self.output_names.first().ok_or_else(|| {
-                    Error::Inference("model missing first output tensor".to_string())
-                })?;
-                let output_1 = self.output_names.get(1).ok_or_else(|| {
-                    Error::Inference("model missing second output tensor".to_string())
-                })?;
-                let embeddings =
-                    Self::extract_tensor_data(outputs, output_0, batch_size * embedding_dim)?;
+                let embeddings_name = self.embeddings_output_name()?;
+                let logits_name = self.predictions_output_name()?;
+                let embeddings = Self::extract_tensor_data(
+                    outputs,
+                    embeddings_name,
+                    batch_size * embedding_dim,
+                )?;
                 let logits =
-                    Self::extract_tensor_data(outputs, output_1, batch_size * self.num_species)?;
+                    Self::extract_tensor_data(outputs, logits_name, batch_size * self.num_species)?;
                 Ok((Some(embeddings), logits))
             }
             ModelType::PerchV2 => Err(Error::Inference("PerchV2 not supported".into())),
         }
+    }
+
+    /// Name of the class-score output, by its resolved index.
+    fn predictions_output_name(&self) -> Result<&str> {
+        self.output_names
+            .get(self.predictions_index)
+            .map(String::as_str)
+            .ok_or_else(|| {
+                Error::Inference(format!(
+                    "model has no output at the class-score index {}",
+                    self.predictions_index
+                ))
+            })
+    }
+
+    /// Name of the embeddings output, by its resolved index.
+    fn embeddings_output_name(&self) -> Result<&str> {
+        let index = self
+            .embeddings_index
+            .ok_or_else(|| Error::Inference("model has no embeddings output".to_string()))?;
+        self.output_names
+            .get(index)
+            .map(String::as_str)
+            .ok_or_else(|| {
+                Error::Inference(format!(
+                    "model has no output at the embeddings index {index}"
+                ))
+            })
     }
 
     /// Extract tensor data from outputs by name.

--- a/src/classifier.rs
+++ b/src/classifier.rs
@@ -387,9 +387,15 @@ impl ClassifierBuilder {
         // Extract input/output shapes for model detection
         let input_shape = extract_input_shape(&session)?;
         let output_shapes = extract_output_shapes(&session)?;
+        let output_names = extract_output_names(&session);
 
         // Detect model type
-        let config = detect_model_type(&input_shape, &output_shapes, self.model_type_override)?;
+        let config = detect_model_type(
+            &input_shape,
+            &output_shapes,
+            &output_names,
+            self.model_type_override,
+        )?;
 
         // Load labels
         let labels = match labels_source {
@@ -437,7 +443,16 @@ fn extract_input_shape(session: &Session) -> Result<Vec<i64>> {
     Ok(shape.iter().copied().collect())
 }
 
-/// Extract output tensor shapes from session
+/// Extract output tensor names from a session, in graph order.
+fn extract_output_names(session: &Session) -> Vec<String> {
+    session
+        .outputs()
+        .iter()
+        .map(|output| output.name().to_string())
+        .collect()
+}
+
+/// Extract output tensor shapes from a session.
 fn extract_output_shapes(session: &Session) -> Result<Vec<Vec<i64>>> {
     session
         .outputs()
@@ -959,10 +974,15 @@ impl Classifier {
                 (None, logits)
             }
             ModelType::BirdNetV30 => {
-                // Two outputs: embeddings at 0, predictions at 1
-                let embeddings = extract_tensor_data(outputs, 0)?;
-                let logits = extract_tensor_data(outputs, 1)?;
-                (Some(embeddings), logits)
+                // Indices resolved during detection, because output order is
+                // not a property of the family: the fp32 and fp16 exports of
+                // the same weights name their class scores differently.
+                let logits = extract_tensor_data(outputs, self.inner.config.predictions_index)?;
+                let embeddings = match self.inner.config.embeddings_index {
+                    Some(index) => Some(extract_tensor_data(outputs, index)?),
+                    None => None,
+                };
+                (embeddings, logits)
             }
             ModelType::PerchV2 => {
                 // Four outputs: embedding at 0, spatial_embedding at 1, spectrogram at 2, predictions at 3
@@ -983,6 +1003,24 @@ impl Classifier {
     }
 
     /// Process batch inference outputs
+    /// Class-score and embedding tensors for a batch, by resolved output index.
+    ///
+    /// One place that knows which output is which, so a family's layout is
+    /// stated once at detection rather than repeated per arm. The arms differed
+    /// on nothing else: v2.4, v3.0 and Perch all read the same two tensors and
+    /// slice them identically.
+    fn batch_tensors(
+        &self,
+        outputs: &ort::session::SessionOutputs,
+    ) -> Result<(Vec<f32>, Vec<f32>)> {
+        let embeddings_index = self.inner.config.embeddings_index.ok_or_else(|| {
+            Error::Inference("embeddings index missing for a model with embeddings".into())
+        })?;
+        let logits = extract_tensor_data(outputs, self.inner.config.predictions_index)?;
+        let embeddings = extract_tensor_data(outputs, embeddings_index)?;
+        Ok((logits, embeddings))
+    }
+
     fn process_batch_outputs(
         &self,
         outputs: &ort::session::SessionOutputs,
@@ -996,8 +1034,7 @@ impl Classifier {
                 let embedding_dim = self.inner.config.embedding_dim.ok_or_else(|| {
                     Error::Inference("embedding_dim missing for v2.4 model with embeddings".into())
                 })?;
-                let logits_flat = extract_tensor_data(outputs, 0)?;
-                let emb_flat = extract_tensor_data(outputs, 1)?;
+                let (logits_flat, emb_flat) = self.batch_tensors(outputs)?;
 
                 (0..batch_size)
                     .map(|i| {
@@ -1046,8 +1083,7 @@ impl Classifier {
                         "embedding_dim missing for model that requires embeddings".into(),
                     )
                 })?;
-                let emb_flat = extract_tensor_data(outputs, 0)?;
-                let logits_flat = extract_tensor_data(outputs, 1)?;
+                let (logits_flat, emb_flat) = self.batch_tensors(outputs)?;
 
                 (0..batch_size)
                     .map(|i| {
@@ -1076,8 +1112,7 @@ impl Classifier {
                         "embedding_dim missing for model that requires embeddings".into(),
                     )
                 })?;
-                let emb_flat = extract_tensor_data(outputs, 0)?;
-                let logits_flat = extract_tensor_data(outputs, 3)?; // predictions at index 3
+                let (logits_flat, emb_flat) = self.batch_tensors(outputs)?;
 
                 (0..batch_size)
                     .map(|i| {

--- a/src/classifier.rs
+++ b/src/classifier.rs
@@ -1035,7 +1035,8 @@ impl Classifier {
                     .collect()
             }
             ModelType::BirdNetV24 | ModelType::BsgFinland => {
-                let logits_flat = extract_tensor_data(outputs, 0)?;
+                let logits_flat =
+                    extract_tensor_data(outputs, self.inner.config.predictions_index)?;
 
                 (0..batch_size)
                     .map(|i| {

--- a/src/classifier.rs
+++ b/src/classifier.rs
@@ -958,38 +958,15 @@ impl Classifier {
     fn process_outputs(&self, outputs: &ort::session::SessionOutputs) -> Result<PredictionResult> {
         let model_type = self.inner.config.model_type;
 
-        let (embeddings, logits) = match model_type {
-            ModelType::BirdNetV24 => {
-                // predictions are always at output 0; embeddings at 1 only for v2.4 with embedding export
-                let logits = extract_tensor_data(outputs, 0)?;
-                if self.inner.config.embedding_dim.is_some() {
-                    let embeddings = extract_tensor_data(outputs, 1)?;
-                    (Some(embeddings), logits)
-                } else {
-                    (None, logits)
-                }
-            }
-            ModelType::BsgFinland => {
-                let logits = extract_tensor_data(outputs, 0)?;
-                (None, logits)
-            }
-            ModelType::BirdNetV30 => {
-                // Indices resolved during detection, because output order is
-                // not a property of the family: the fp32 and fp16 exports of
-                // the same weights name their class scores differently.
-                let logits = extract_tensor_data(outputs, self.inner.config.predictions_index)?;
-                let embeddings = match self.inner.config.embeddings_index {
-                    Some(index) => Some(extract_tensor_data(outputs, index)?),
-                    None => None,
-                };
-                (embeddings, logits)
-            }
-            ModelType::PerchV2 => {
-                // Four outputs: embedding at 0, spatial_embedding at 1, spectrogram at 2, predictions at 3
-                let embeddings = extract_tensor_data(outputs, 0)?;
-                let logits = extract_tensor_data(outputs, 3)?;
-                (Some(embeddings), logits)
-            }
+        // Every family reads the same two tensors, and detection already worked
+        // out which is which. Keeping a per-family index here is what let the
+        // v3.0 assumption survive in five places at once, so there is now one
+        // rule: ask the config. A model with no embeddings output simply has no
+        // embeddings index.
+        let logits = extract_tensor_data(outputs, self.inner.config.predictions_index)?;
+        let embeddings = match self.inner.config.embeddings_index {
+            Some(index) => Some(extract_tensor_data(outputs, index)?),
+            None => None,
         };
 
         let predictions = self.select_top_k(&logits);

--- a/src/detection.rs
+++ b/src/detection.rs
@@ -502,6 +502,67 @@ mod tests {
     }
 
     #[test]
+    fn test_every_detected_config_indexes_an_output_that_exists() {
+        // Inference now reads whatever these point at, for every family, so an
+        // index outside the model's outputs would be an out-of-bounds read
+        // rather than the loud shape mismatch it used to be.
+        let cases: Vec<(Vec<i64>, Vec<Vec<i64>>, Vec<String>)> = vec![
+            (vec![1, 144_000], vec![vec![1, 6522]], names(&["output"])),
+            (
+                vec![1, 144_000],
+                vec![vec![1, 6522], vec![1, 1024]],
+                names(&["output", "model/GLOBAL_AVG_POOL/Mean_reduced_0"]),
+            ),
+            (
+                vec![1, 160_000],
+                vec![vec![1, 11_560], vec![1, 1280]],
+                names(&["predictions", "embeddings"]),
+            ),
+            (
+                vec![1, 160_000],
+                vec![vec![1, 422], vec![1, 1280]],
+                names(&["output", "embeddings"]),
+            ),
+            (
+                vec![1, 160_000],
+                vec![
+                    vec![1, 1536],
+                    vec![1, 16, 4, 1536],
+                    vec![1, 500, 128],
+                    vec![1, 638],
+                ],
+                names(&["embedding", "spatial_embedding", "spectrogram", "label"]),
+            ),
+        ];
+
+        for (input_shape, output_shapes, output_names) in cases {
+            let config =
+                detect_model_type(&input_shape, &output_shapes, &output_names, None).unwrap();
+
+            assert!(
+                config.predictions_index < output_shapes.len(),
+                "{:?}: class-score index {} is out of range",
+                output_names,
+                config.predictions_index
+            );
+            assert_eq!(
+                extract_last_dim(&output_shapes[config.predictions_index]).unwrap(),
+                config.num_species,
+                "{output_names:?}: class-score index does not point at the class scores"
+            );
+
+            if let Some(index) = config.embeddings_index {
+                assert!(index < output_shapes.len());
+                assert_eq!(
+                    extract_last_dim(&output_shapes[index]).unwrap(),
+                    config.embedding_dim.unwrap(),
+                    "{output_names:?}: embeddings index does not point at the embeddings"
+                );
+            }
+        }
+    }
+
+    #[test]
     fn test_an_override_still_resolves_roles_from_names() {
         // Passing --model v30 used to bypass name resolution and assume the
         // layout, so an explicit override failed on exactly the models an

--- a/src/detection.rs
+++ b/src/detection.rs
@@ -3,11 +3,71 @@
 use crate::error::{Error, Result};
 use crate::types::{ModelConfig, ModelType};
 
+/// Output names that identify an embeddings tensor, lowercased.
+///
+/// Deliberately keyed on the embeddings output rather than the class-score one.
+/// Across the supported exports the embeddings name is stable while the class
+/// scores answer to at least three different names: `BirdNET` v3.0 fp32 calls
+/// them `predictions`, its fp16 export of the SAME weights calls them `output`,
+/// and `Perch` v2 calls them `label`.
+const EMBEDDING_OUTPUT_NAMES: &[&str] = &["embeddings", "embedding"];
+
+/// Which output carries what, for a two-output model.
+///
+/// Resolved from names where they say so, because output ORDER is not a
+/// property of a model family. Every published `BirdNET` v3.0 export puts the
+/// embeddings second, which is the opposite of what this crate assumed until
+/// the models were tested against it, and reading the embedding tensor as class
+/// scores is silent nonsense rather than an error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct OutputRoles {
+    /// Index of the class-score tensor.
+    predictions: usize,
+    /// Index of the embeddings tensor.
+    embeddings: usize,
+}
+
+/// Locate the embeddings and class-score outputs of a two-output model.
+///
+/// Falls back to "class scores first, embeddings second" when the names say
+/// nothing, which is the layout of every published two-output model this crate
+/// has been tested against, `BirdNET` v3.0 and v2.4-with-embeddings alike.
+fn resolve_two_output_roles(output_names: &[String]) -> OutputRoles {
+    const FALLBACK: OutputRoles = OutputRoles {
+        predictions: 0,
+        embeddings: 1,
+    };
+
+    let embedding_positions: Vec<usize> = output_names
+        .iter()
+        .enumerate()
+        .filter(|(_, name)| {
+            let name = name.to_ascii_lowercase();
+            EMBEDDING_OUTPUT_NAMES.contains(&name.as_str())
+        })
+        .map(|(index, _)| index)
+        .collect();
+
+    // Exactly one match, or the name told us nothing useful. Two outputs both
+    // claiming to be embeddings is a model we do not understand, and guessing
+    // between them would be worse than the documented default.
+    match embedding_positions.as_slice() {
+        [embeddings] if output_names.len() == 2 => OutputRoles {
+            predictions: 1 - embeddings,
+            embeddings: *embeddings,
+        },
+        _ => FALLBACK,
+    }
+}
+
 /// Detects model type from ONNX input/output tensor shapes.
 ///
 /// # Arguments
 /// * `input_shape` - Input tensor shape, expected `[batch, samples]` or `[batch, 1, samples]`
 /// * `output_shapes` - Output tensor shapes
+/// * `output_names` - Output tensor names, in the same order as `output_shapes`.
+///   Pass an empty slice when they are unavailable, and detection falls back to
+///   positional layout.
 /// * `override_type` - Optional user override for ambiguous models (v3.0 vs `Perch`)
 ///
 /// # Errors
@@ -15,6 +75,7 @@ use crate::types::{ModelConfig, ModelType};
 pub fn detect_model_type(
     input_shape: &[i64],
     output_shapes: &[Vec<i64>],
+    output_names: &[String],
     override_type: Option<ModelType>,
 ) -> Result<ModelConfig> {
     let sample_count_opt = extract_sample_count(input_shape);
@@ -23,16 +84,16 @@ pub fn detect_model_type(
     // If user provided override, validate and use it
     if let Some(model_type) = override_type {
         let sample_count = sample_count_opt.unwrap_or_else(|| model_type.sample_count());
-        return build_config_with_override(model_type, sample_count, output_shapes);
+        return build_config_with_override(model_type, sample_count, output_shapes, output_names);
     }
 
     // If sample count is known, use it for detection
     if let Some(sample_count) = sample_count_opt {
-        return detect_from_sample_count(sample_count, num_outputs, output_shapes);
+        return detect_from_sample_count(sample_count, num_outputs, output_shapes, output_names);
     }
 
     // Input has dynamic dimensions - infer from output shapes
-    detect_from_outputs(num_outputs, output_shapes)
+    detect_from_outputs(num_outputs, output_shapes, output_names)
 }
 
 /// Detect model type from known sample count and output patterns.
@@ -40,6 +101,7 @@ fn detect_from_sample_count(
     sample_count: usize,
     num_outputs: usize,
     output_shapes: &[Vec<i64>],
+    output_names: &[String],
 ) -> Result<ModelConfig> {
     // Auto-detection based on sample count and output count
     match (sample_count, num_outputs) {
@@ -53,14 +115,16 @@ fn detect_from_sample_count(
                 sample_count: 144_000,
                 num_species,
                 embedding_dim: None,
+                predictions_index: 0,
+                embeddings_index: None,
             })
         }
 
-        // BirdNET v2.4 with embeddings: 144,000 samples, 2 outputs
-        // (predictions at 0, embeddings at 1)
+        // BirdNET v2.4 with embeddings: 144,000 samples, 2 outputs.
         (144_000, 2) => {
-            let num_species = extract_last_dim(&output_shapes[0])?;
-            let embedding_dim = extract_last_dim(&output_shapes[1])?;
+            let roles = resolve_two_output_roles(output_names);
+            let num_species = extract_last_dim(&output_shapes[roles.predictions])?;
+            let embedding_dim = extract_last_dim(&output_shapes[roles.embeddings])?;
             Ok(ModelConfig {
                 model_type: ModelType::BirdNetV24,
                 sample_rate: 48_000,
@@ -68,13 +132,16 @@ fn detect_from_sample_count(
                 sample_count: 144_000,
                 num_species,
                 embedding_dim: Some(embedding_dim),
+                predictions_index: roles.predictions,
+                embeddings_index: Some(roles.embeddings),
             })
         }
 
-        // `BirdNET` v3.0: 160,000 samples, 2 outputs (embeddings, predictions)
+        // `BirdNET` v3.0: 160,000 samples, 2 outputs.
         (160_000, 2) => {
-            let embedding_dim = extract_last_dim(&output_shapes[0])?;
-            let num_species = extract_last_dim(&output_shapes[1])?;
+            let roles = resolve_two_output_roles(output_names);
+            let embedding_dim = extract_last_dim(&output_shapes[roles.embeddings])?;
+            let num_species = extract_last_dim(&output_shapes[roles.predictions])?;
 
             Ok(ModelConfig {
                 model_type: ModelType::BirdNetV30,
@@ -83,6 +150,8 @@ fn detect_from_sample_count(
                 sample_count: 160_000,
                 num_species,
                 embedding_dim: Some(embedding_dim),
+                predictions_index: roles.predictions,
+                embeddings_index: Some(roles.embeddings),
             })
         }
 
@@ -98,6 +167,8 @@ fn detect_from_sample_count(
                 sample_count: 160_000,
                 num_species,
                 embedding_dim: Some(embedding_dim),
+                predictions_index: 3,
+                embeddings_index: Some(0),
             })
         }
 
@@ -110,8 +181,17 @@ fn detect_from_sample_count(
     }
 }
 
+/// Embedding width of `BirdNET` v3.0, the one two-output family this crate can
+/// name from its embedding tensor alone. v2.4's 1024 is not listed because it
+/// is the default rather than a signal.
+const V30_EMBEDDING_DIM: usize = 1280;
+
 /// Detect model type from output shapes when input dimensions are dynamic.
-fn detect_from_outputs(num_outputs: usize, output_shapes: &[Vec<i64>]) -> Result<ModelConfig> {
+fn detect_from_outputs(
+    num_outputs: usize,
+    output_shapes: &[Vec<i64>],
+    output_names: &[String],
+) -> Result<ModelConfig> {
     match num_outputs {
         // `BirdNET` v2.4: 1 output
         1 => {
@@ -123,39 +203,45 @@ fn detect_from_outputs(num_outputs: usize, output_shapes: &[Vec<i64>]) -> Result
                 sample_count: 144_000,
                 num_species,
                 embedding_dim: None,
+                predictions_index: 0,
+                embeddings_index: None,
             })
         }
 
-        // 2 outputs: either v2.4-with-embeddings or v3.0, distinguished by output order.
-        // v2.4 with embeddings: first output is large (predictions),
-        // second is small (1024 embeddings).
-        // v3.0: first output is small (1280 embeddings),
-        // second is large (predictions).
+        // 2 outputs: either v2.4-with-embeddings or v3.0.
+        //
+        // Which output is which comes from the names; which FAMILY it is comes
+        // from the embedding width, 1024 for v2.4 and 1280 for v3.0. The two
+        // questions are separate, and conflating them is what made this branch
+        // wrong: it decided the family by "is the first output bigger", which
+        // is true for a v3.0 export that puts its 11,560 class scores ahead of
+        // its 1,280-wide embeddings, so every such model was detected as v2.4
+        // and run at 48 kHz with a 3 second window.
         2 => {
-            let first_dim = extract_last_dim(&output_shapes[0])?;
-            let second_dim = extract_last_dim(&output_shapes[1])?;
+            let roles = resolve_two_output_roles(output_names);
+            let num_species = extract_last_dim(&output_shapes[roles.predictions])?;
+            let embedding_dim = extract_last_dim(&output_shapes[roles.embeddings])?;
 
-            if first_dim > second_dim {
-                // v2.4 pattern: predictions at 0, embeddings at 1
-                Ok(ModelConfig {
-                    model_type: ModelType::BirdNetV24,
-                    sample_rate: 48_000,
-                    segment_duration: 3.0,
-                    sample_count: 144_000,
-                    num_species: first_dim,
-                    embedding_dim: Some(second_dim),
-                })
+            // Only v3.0's width is a positive signal. v2.4 is the default for
+            // its own width and for anything unrecognised alike, because an
+            // embedding tensor narrower than the class scores is the shape both
+            // families share and so distinguishes nothing.
+            let model_type = if embedding_dim == V30_EMBEDDING_DIM {
+                ModelType::BirdNetV30
             } else {
-                // v3.0 pattern: embeddings at 0, predictions at 1
-                Ok(ModelConfig {
-                    model_type: ModelType::BirdNetV30,
-                    sample_rate: 32_000,
-                    segment_duration: 5.0,
-                    sample_count: 160_000,
-                    num_species: second_dim,
-                    embedding_dim: Some(first_dim),
-                })
-            }
+                ModelType::BirdNetV24
+            };
+
+            Ok(ModelConfig {
+                model_type,
+                sample_rate: model_type.sample_rate(),
+                segment_duration: model_type.segment_duration(),
+                sample_count: model_type.sample_count(),
+                num_species,
+                embedding_dim: Some(embedding_dim),
+                predictions_index: roles.predictions,
+                embeddings_index: Some(roles.embeddings),
+            })
         }
 
         // `Perch` v2: 4 outputs
@@ -170,6 +256,8 @@ fn detect_from_outputs(num_outputs: usize, output_shapes: &[Vec<i64>]) -> Result
                 sample_count: 160_000,
                 num_species,
                 embedding_dim: Some(embedding_dim),
+                predictions_index: 3,
+                embeddings_index: Some(0),
             })
         }
 
@@ -187,6 +275,7 @@ fn build_config_with_override(
     model_type: ModelType,
     sample_count: usize,
     output_shapes: &[Vec<i64>],
+    output_names: &[String],
 ) -> Result<ModelConfig> {
     let expected_samples = model_type.sample_count();
     if sample_count != expected_samples {
@@ -198,13 +287,28 @@ fn build_config_with_override(
         });
     }
 
-    let (embedding_dim, num_species) = match model_type {
+    // An override says which FAMILY this is. It says nothing about which output
+    // is which, so the roles are resolved from the names exactly as they are on
+    // the auto-detection path. Assuming a layout here was the reason `--model
+    // v30` failed on the published models in the same way auto-detection did.
+    let (embedding_dim, num_species, roles) = match model_type {
         ModelType::BirdNetV24 => match output_shapes.len() {
-            1 => (None, extract_last_dim(&output_shapes[0])?),
-            2 => (
-                Some(extract_last_dim(&output_shapes[1])?),
+            1 => (
+                None,
                 extract_last_dim(&output_shapes[0])?,
+                OutputRoles {
+                    predictions: 0,
+                    embeddings: 0,
+                },
             ),
+            2 => {
+                let roles = resolve_two_output_roles(output_names);
+                (
+                    Some(extract_last_dim(&output_shapes[roles.embeddings])?),
+                    extract_last_dim(&output_shapes[roles.predictions])?,
+                    roles,
+                )
+            }
             n => {
                 return Err(Error::ModelDetection {
                     reason: format!("BirdNET v2.4 expects 1 or 2 outputs, got {n}"),
@@ -220,9 +324,11 @@ fn build_config_with_override(
                     ),
                 });
             }
+            let roles = resolve_two_output_roles(output_names);
             (
-                Some(extract_last_dim(&output_shapes[0])?),
-                extract_last_dim(&output_shapes[1])?,
+                Some(extract_last_dim(&output_shapes[roles.embeddings])?),
+                extract_last_dim(&output_shapes[roles.predictions])?,
+                roles,
             )
         }
         ModelType::PerchV2 => {
@@ -234,6 +340,10 @@ fn build_config_with_override(
             (
                 Some(extract_last_dim(&output_shapes[0])?),
                 extract_last_dim(&output_shapes[3])?, // predictions at index 3
+                OutputRoles {
+                    predictions: 3,
+                    embeddings: 0,
+                },
             )
         }
         ModelType::BsgFinland => {
@@ -242,7 +352,14 @@ fn build_config_with_override(
                     reason: format!("BSG Finland expects 1 output, got {}", output_shapes.len()),
                 });
             }
-            (None, extract_last_dim(&output_shapes[0])?)
+            (
+                None,
+                extract_last_dim(&output_shapes[0])?,
+                OutputRoles {
+                    predictions: 0,
+                    embeddings: 0,
+                },
+            )
         }
     };
 
@@ -253,6 +370,8 @@ fn build_config_with_override(
         sample_count,
         num_species,
         embedding_dim,
+        predictions_index: roles.predictions,
+        embeddings_index: embedding_dim.map(|_| roles.embeddings),
     })
 }
 
@@ -292,12 +411,125 @@ mod tests {
     #![allow(clippy::float_cmp)]
     use super::*;
 
+    /// Output names as the session reports them.
+    fn names(values: &[&str]) -> Vec<String> {
+        values.iter().map(|v| (*v).to_string()).collect()
+    }
+
+    #[test]
+    fn test_roles_find_the_embeddings_output_in_either_position() {
+        assert_eq!(
+            resolve_two_output_roles(&names(&["predictions", "embeddings"])),
+            OutputRoles {
+                predictions: 0,
+                embeddings: 1
+            }
+        );
+        assert_eq!(
+            resolve_two_output_roles(&names(&["embeddings", "predictions"])),
+            OutputRoles {
+                predictions: 1,
+                embeddings: 0
+            }
+        );
+    }
+
+    #[test]
+    fn test_roles_accept_the_singular_embedding_spelling() {
+        // Perch spells it `embedding`. Supporting both costs nothing and
+        // avoids a fix that works for one publisher's habit only.
+        assert_eq!(
+            resolve_two_output_roles(&names(&["embedding", "label"])),
+            OutputRoles {
+                predictions: 1,
+                embeddings: 0
+            }
+        );
+    }
+
+    #[test]
+    fn test_roles_ignore_case_in_output_names() {
+        assert_eq!(
+            resolve_two_output_roles(&names(&["Output", "Embeddings"])),
+            OutputRoles {
+                predictions: 0,
+                embeddings: 1
+            }
+        );
+    }
+
+    #[test]
+    fn test_roles_fall_back_when_no_name_identifies_the_embeddings() {
+        // BirdNET v2.4's embedding export, whose second output is named
+        // `model/GLOBAL_AVG_POOL/Mean_reduced_0`. The fallback is the layout it
+        // actually has, so this keeps working.
+        let roles =
+            resolve_two_output_roles(&names(&["output", "model/GLOBAL_AVG_POOL/Mean_reduced_0"]));
+
+        assert_eq!(
+            roles,
+            OutputRoles {
+                predictions: 0,
+                embeddings: 1
+            }
+        );
+    }
+
+    #[test]
+    fn test_roles_fall_back_when_both_outputs_claim_to_be_embeddings() {
+        // Guessing between two equally plausible candidates would be worse
+        // than the documented default.
+        let roles = resolve_two_output_roles(&names(&["embeddings", "embedding"]));
+
+        assert_eq!(
+            roles,
+            OutputRoles {
+                predictions: 0,
+                embeddings: 1
+            }
+        );
+    }
+
+    #[test]
+    fn test_roles_fall_back_on_an_empty_name_list() {
+        assert_eq!(
+            resolve_two_output_roles(&[]),
+            OutputRoles {
+                predictions: 0,
+                embeddings: 1
+            }
+        );
+    }
+
+    #[test]
+    fn test_an_override_still_resolves_roles_from_names() {
+        // Passing --model v30 used to bypass name resolution and assume the
+        // layout, so an explicit override failed on exactly the models an
+        // override exists to rescue.
+        let input_shape = vec![1, 160_000];
+        let output_shapes = vec![vec![1, 422], vec![1, 1280]];
+        let names = names(&["output", "embeddings"]);
+
+        let config = detect_model_type(
+            &input_shape,
+            &output_shapes,
+            &names,
+            Some(ModelType::BirdNetV30),
+        )
+        .unwrap();
+
+        assert_eq!(config.num_species, 422);
+        assert_eq!(config.embedding_dim, Some(1280));
+        assert_eq!(config.predictions_index, 0);
+        assert_eq!(config.embeddings_index, Some(1));
+    }
+
     #[test]
     fn test_detect_birdnet_v24() {
         let input_shape = vec![1, 144_000];
         let output_shapes = vec![vec![1, 6522]];
 
-        let config = detect_model_type(&input_shape, &output_shapes, None).unwrap();
+        let config = detect_model_type(&input_shape, &output_shapes, &[], None).unwrap();
 
         assert_eq!(config.model_type, ModelType::BirdNetV24);
         assert_eq!(config.sample_rate, 48_000);
@@ -309,17 +541,71 @@ mod tests {
 
     #[test]
     fn test_detect_birdnet_v30() {
+        // The published fp32 layout: class scores first, named `predictions`.
         let input_shape = vec![1, 160_000];
-        let output_shapes = vec![vec![1, 1024], vec![1, 1000]];
+        let output_shapes = vec![vec![1, 11_560], vec![1, 1280]];
+        let names = names(&["predictions", "embeddings"]);
 
-        let config = detect_model_type(&input_shape, &output_shapes, None).unwrap();
+        let config = detect_model_type(&input_shape, &output_shapes, &names, None).unwrap();
 
         assert_eq!(config.model_type, ModelType::BirdNetV30);
         assert_eq!(config.sample_rate, 32_000);
         assert_eq!(config.segment_duration, 5.0);
         assert_eq!(config.sample_count, 160_000);
-        assert_eq!(config.num_species, 1000);
-        assert_eq!(config.embedding_dim, Some(1024));
+        assert_eq!(config.num_species, 11_560);
+        assert_eq!(config.embedding_dim, Some(1280));
+        assert_eq!(config.predictions_index, 0);
+        assert_eq!(config.embeddings_index, Some(1));
+    }
+
+    #[test]
+    fn test_detect_birdnet_v30_fp16_names_its_scores_output() {
+        // Same weights, different export: the fp16 file calls its class scores
+        // `output`, not `predictions`. Keying on the class-score name would fix
+        // one variant of a model and leave the other broken, which is why the
+        // embeddings name is what identifies the pair.
+        let input_shape = vec![1, 160_000];
+        let output_shapes = vec![vec![1, 422], vec![1, 1280]];
+        let names = names(&["output", "embeddings"]);
+
+        let config = detect_model_type(&input_shape, &output_shapes, &names, None).unwrap();
+
+        assert_eq!(config.model_type, ModelType::BirdNetV30);
+        assert_eq!(config.num_species, 422);
+        assert_eq!(config.embedding_dim, Some(1280));
+        assert_eq!(config.predictions_index, 0);
+        assert_eq!(config.embeddings_index, Some(1));
+    }
+
+    #[test]
+    fn test_detect_birdnet_v30_with_embeddings_first() {
+        // Order must not matter once the names are known. This is the layout
+        // the crate assumed for every v3.0 model, and getting it from the names
+        // rather than the position is the whole point.
+        let input_shape = vec![1, 160_000];
+        let output_shapes = vec![vec![1, 1280], vec![1, 11_560]];
+        let names = names(&["embeddings", "predictions"]);
+
+        let config = detect_model_type(&input_shape, &output_shapes, &names, None).unwrap();
+
+        assert_eq!(config.num_species, 11_560);
+        assert_eq!(config.embedding_dim, Some(1280));
+        assert_eq!(config.predictions_index, 1);
+        assert_eq!(config.embeddings_index, Some(0));
+    }
+
+    #[test]
+    fn test_detect_two_output_model_without_names_assumes_scores_first() {
+        // The documented fallback. Every published two-output model puts its
+        // class scores first, so that is what an unnamed pair is read as.
+        let input_shape = vec![1, 160_000];
+        let output_shapes = vec![vec![1, 11_560], vec![1, 1280]];
+
+        let config = detect_model_type(&input_shape, &output_shapes, &[], None).unwrap();
+
+        assert_eq!(config.num_species, 11_560);
+        assert_eq!(config.embedding_dim, Some(1280));
+        assert_eq!(config.predictions_index, 0);
     }
 
     #[test]
@@ -333,7 +619,7 @@ mod tests {
             vec![1, 14795],       // predictions
         ];
 
-        let config = detect_model_type(&input_shape, &output_shapes, None).unwrap();
+        let config = detect_model_type(&input_shape, &output_shapes, &[], None).unwrap();
 
         assert_eq!(config.model_type, ModelType::PerchV2);
         assert_eq!(config.sample_rate, 32_000);
@@ -355,7 +641,7 @@ mod tests {
         ];
 
         let config =
-            detect_model_type(&input_shape, &output_shapes, Some(ModelType::PerchV2)).unwrap();
+            detect_model_type(&input_shape, &output_shapes, &[], Some(ModelType::PerchV2)).unwrap();
 
         assert_eq!(config.model_type, ModelType::PerchV2);
         assert_eq!(config.embedding_dim, Some(512));
@@ -368,7 +654,12 @@ mod tests {
         let output_shapes = vec![vec![1, 1024], vec![1, 1000]];
 
         // `BirdNET` v2.4 expects 144,000 samples, not 160,000
-        let result = detect_model_type(&input_shape, &output_shapes, Some(ModelType::BirdNetV24));
+        let result = detect_model_type(
+            &input_shape,
+            &output_shapes,
+            &[],
+            Some(ModelType::BirdNetV24),
+        );
 
         assert!(result.is_err());
     }
@@ -378,7 +669,7 @@ mod tests {
         let input_shape = vec![1, 100_000]; // Wrong sample count
         let output_shapes = vec![vec![1, 1000]];
 
-        let result = detect_model_type(&input_shape, &output_shapes, None);
+        let result = detect_model_type(&input_shape, &output_shapes, &[], None);
 
         assert!(result.is_err());
         let err = result.unwrap_err();
@@ -408,8 +699,9 @@ mod tests {
         // Input shape with dynamic dimensions
         let input_shape = vec![-1, -1];
         let output_shapes = vec![vec![-1, 1280], vec![-1, 11560]];
+        let names = names(&["embeddings", "predictions"]);
 
-        let config = detect_model_type(&input_shape, &output_shapes, None).unwrap();
+        let config = detect_model_type(&input_shape, &output_shapes, &names, None).unwrap();
 
         assert_eq!(config.model_type, ModelType::BirdNetV30);
         assert_eq!(config.sample_rate, 32_000);
@@ -430,7 +722,7 @@ mod tests {
             vec![-1, 14795],       // predictions
         ];
 
-        let config = detect_model_type(&input_shape, &output_shapes, None).unwrap();
+        let config = detect_model_type(&input_shape, &output_shapes, &[], None).unwrap();
 
         assert_eq!(config.model_type, ModelType::PerchV2);
         assert_eq!(config.sample_count, 160_000);
@@ -444,7 +736,7 @@ mod tests {
         // v2.4 with embeddings: predictions at 0, embeddings at 1
         let output_shapes = vec![vec![1, 6522], vec![1, 1024]];
 
-        let config = detect_model_type(&input_shape, &output_shapes, None).unwrap();
+        let config = detect_model_type(&input_shape, &output_shapes, &[], None).unwrap();
 
         assert_eq!(config.model_type, ModelType::BirdNetV24);
         assert_eq!(config.sample_rate, 48_000);
@@ -459,7 +751,7 @@ mod tests {
         let input_shape = vec![-1, -1];
         let output_shapes = vec![vec![-1, 6522], vec![-1, 1024]];
 
-        let config = detect_model_type(&input_shape, &output_shapes, None).unwrap();
+        let config = detect_model_type(&input_shape, &output_shapes, &[], None).unwrap();
 
         assert_eq!(config.model_type, ModelType::BirdNetV24);
         assert_eq!(config.embedding_dim, Some(1024));
@@ -470,8 +762,13 @@ mod tests {
         let input_shape = vec![1, 144_000];
         let output_shapes = vec![vec![1, 6522], vec![1, 1024]];
 
-        let config =
-            detect_model_type(&input_shape, &output_shapes, Some(ModelType::BirdNetV24)).unwrap();
+        let config = detect_model_type(
+            &input_shape,
+            &output_shapes,
+            &[],
+            Some(ModelType::BirdNetV24),
+        )
+        .unwrap();
 
         assert_eq!(config.model_type, ModelType::BirdNetV24);
         assert_eq!(config.embedding_dim, Some(1024));

--- a/src/detection.rs
+++ b/src/detection.rs
@@ -506,7 +506,10 @@ mod tests {
         // Inference now reads whatever these point at, for every family, so an
         // index outside the model's outputs would be an out-of-bounds read
         // rather than the loud shape mismatch it used to be.
-        let cases: Vec<(Vec<i64>, Vec<Vec<i64>>, Vec<String>)> = vec![
+        /// One model's shape: input shape, output shapes, output names.
+        type Case = (Vec<i64>, Vec<Vec<i64>>, Vec<String>);
+
+        let cases: Vec<Case> = vec![
             (vec![1, 144_000], vec![vec![1, 6522]], names(&["output"])),
             (
                 vec![1, 144_000],

--- a/src/testutil.rs
+++ b/src/testutil.rs
@@ -44,6 +44,17 @@ pub fn mock_config(model_type: ModelType) -> ModelConfig {
             ModelType::BirdNetV30 => Some(1024),
             ModelType::PerchV2 => Some(512),
         },
+        // The published layouts: class scores first for the two-output
+        // families, last for Perch's four.
+        predictions_index: match model_type {
+            ModelType::BirdNetV24 | ModelType::BsgFinland | ModelType::BirdNetV30 => 0,
+            ModelType::PerchV2 => 3,
+        },
+        embeddings_index: match model_type {
+            ModelType::BirdNetV24 | ModelType::BsgFinland => None,
+            ModelType::BirdNetV30 => Some(1),
+            ModelType::PerchV2 => Some(0),
+        },
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -98,6 +98,17 @@ pub struct ModelConfig {
     pub num_species: usize,
     /// Embedding dimension (None for v2.4).
     pub embedding_dim: Option<usize>,
+    /// Index of the output tensor carrying class scores.
+    ///
+    /// Resolved once during detection so no consumer has to hardcode it.
+    /// Output ORDER is not a property of a model family: `BirdNET` v3.0 ships
+    /// the same weights with the class scores named `predictions` in its fp32
+    /// export and `output` in its fp16 export, and an assumed index that is
+    /// wrong reads the embedding tensor as class scores, which is silent
+    /// nonsense rather than an error.
+    pub predictions_index: usize,
+    /// Index of the output tensor carrying embeddings, when the model has one.
+    pub embeddings_index: Option<usize>,
 }
 
 /// Single species prediction.


### PR DESCRIPTION
## Summary

Every published BirdNET v3.0 model fails to load:

```
error: failed to build classifier: label count mismatch: model expects 1280, got 422
```

1280 is the embedding width, not a class count. The crate assumed v3.0 outputs are ordered `(embeddings, predictions)`; every published export has them the other way round, so detection read the embedding tensor's width as the class count and rejected the labels file that matched the real one.

## Why name-based, and why keyed on the embeddings output

Output order is not a property of a model family, and neither is the class-score name:

| model | outputs |
|---|---|
| BirdNET v3.0 fp32 | `predictions`, `embeddings` |
| BirdNET v3.0 fp16 (same weights) | `output`, `embeddings` |
| BirdNET v2.4 + embeddings | `output`, `model/GLOBAL_AVG_POOL/Mean_reduced_0` |
| Perch v2 | `embedding`, `spatial_embedding`, `spectrogram`, `label` |

Keying on the class-score name would have fixed one variant of v3.0 and left the other broken. The embeddings name is the stable one, so it identifies the pair and the other output is the class scores. A two-output model whose names say nothing falls back to class-scores-first, which is the layout of every published two-output model including v2.4-with-embeddings, and two outputs both claiming to be embeddings falls back rather than guessing.

## What changed

Roles are resolved once during detection and carried in `ModelConfig` as `predictions_index` and `embeddings_index`, so no consumer hardcodes an index. That covers the five places that each held their own copy of the assumption: both detection paths, the override path, single-segment inference, batch inference, and the `IoBinding` batch context. An explicit `--model v30` failed in exactly the same way as auto-detection, because the override path assumed the layout too.

Two further bugs fell out of the same reasoning:

- The dynamic-input path decided the family with "is the first output bigger", which is true for a v3.0 export listing 11,560 class scores ahead of 1,280-wide embeddings, so such a model was detected as v2.4 and run at 48 kHz with a 3 second window. Family now comes from the embedding width, which is what actually distinguishes the two.
- Perch's batch arm hardcoded outputs 0 and 3. It now uses the resolved indices like everything else, through a shared helper; the three batch arms differed on nothing but those indices.

## API change

`detect_model_type` takes an `output_names: &[String]` argument, and `ModelConfig` gains two fields. Both are breaking, which is why this targets the 2.0.0-rc line. Passing an empty name slice selects the documented positional fallback.

## Test Plan

- [x] `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` all green
- [x] The two existing v3.0 detection tests asserted the wrong layout, which is why the bug looked correct for as long as it did. They now describe the published models.
- [x] New resolver tests: both namings, both orders, singular `embedding`, case insensitivity, the v2.4 opaque-name fallback, the both-claim-embeddings ambiguity, the empty-names fallback, and the override path
- [x] Verified against real models through birda, with a local path patch: the nordic v3.0 slice in **fp16** and **fp32** each produce 205 detections with *Glaucidium passerinum* top at 0.731 in 40 of 41 segments, which is the bird actually in the recording, and the two variants agree exactly
- [x] Perch v2 regional unaffected: same detections before and after

## Follow-up

Once this is tagged and published, birda needs its dependency bumped to `2.0.0-rc.16`; its gallery already ships v3.0 entries that install correctly but cannot run until then.