### PR TITLE
fix: pin ort to =2.0.0-rc.12 so a fresh install compiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Species Distribution Model (SDM) adjustment using migration curves and geographic distribution maps
   - CLI flags: `--calibration`, `--migration`, `--distribution-maps`, `--lat`, `--lon`, `--day-of-year`, `--csv`
 
+### Fixed
+
+- **A fresh install of the crate did not compile.** The `ort` requirement was
+  written as `"2.0.0-rc.11"`, which cargo reads as a caret range, so any new
+  dependant resolved `ort` to the newest release candidate. rc.13 relocated the
+  `ort::ep::*` execution provider types and the build failed on unresolved
+  imports. `ort` is now pinned to `=2.0.0-rc.12`, the only release candidate
+  this crate compiles against (rc.11 does not export `IoBinding`).
+- The README installation snippets asked for `birdnet-onnx = "2.0"`, which
+  cargo never matches because every 2.0.0 release so far is a pre-release. Both
+  snippets now name the version in full.
+
 ## [2.0.0-rc.1] - 2026-01-04
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,12 @@ cuda = ["ort/cuda"]
 load-dynamic = ["ort/load-dynamic"]  # Optional: for users who want runtime loading
 
 [dependencies]
-ort = { version = "2.0.0-rc.11", features = ["download-binaries", "tracing", "ndarray"] }
+# Pinned exactly. ort is pre-1.0 in spirit: each release candidate moves the
+# API, and cargo treats "2.0.0-rc.11" as a caret range that happily resolves
+# to any later rc. rc.11 does not export `IoBinding`, and rc.13 relocates the
+# `ort::ep::*` execution provider types, so both fail to compile. Only rc.12
+# builds. Widen this only after verifying the crate against the new rc.
+ort = { version = "=2.0.0-rc.12", features = ["download-binaries", "tracing", "ndarray"] }
 thiserror = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/README.md
+++ b/README.md
@@ -36,8 +36,11 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-birdnet-onnx = "2.0"
+birdnet-onnx = "2.0.0-rc.16"
 ```
+
+2.0.0 is still in release candidates, and cargo does not match a pre-release
+from a plain `"2.0"` requirement, so the version has to be spelled out in full.
 
 ### ONNX Runtime Linking
 
@@ -51,7 +54,7 @@ For dynamic linking (loads ONNX Runtime at runtime):
 
 ```toml
 [dependencies]
-birdnet-onnx = { version = "2.0", features = ["load-dynamic"] }
+birdnet-onnx = { version = "2.0.0-rc.16", features = ["load-dynamic"] }
 ```
 
 With dynamic linking, you must ensure the correct ONNX Runtime library is available:


### PR DESCRIPTION
## The problem

`birdnet-onnx` currently does not build for anyone who adds it fresh. This is not a regression in the lockfile refresh from #96; it is a latent problem in the published manifest that went live the moment `ort` 2.0.0-rc.13 hit crates.io.

The manifest asked for:

```toml
ort = { version = "2.0.0-rc.11", ... }
```

Cargo reads a bare `"2.0.0-rc.11"` as a caret range, so it resolves to the newest release candidate rather than the one that was tested. rc.13 relocated the `ort::ep::*` execution provider types, so the build dies on unresolved imports for `CUDAExecutionProvider`, `TensorRTExecutionProvider`, `XNNPACK` and the rest.

Reproduced against the published 2.0.0-rc.15, not just against this working tree:

```toml
[dependencies]
birdnet-onnx = "2.0.0-rc.15"
```

resolves `ort` to 2.0.0-rc.13 and fails.

Pinning the consumer's `ort` by hand shows which release candidates actually work:

| ort | Result |
| --- | --- |
| 2.0.0-rc.11 | `error[E0603]: struct `IoBinding` is private` |
| 2.0.0-rc.12 | builds |
| 2.0.0-rc.13 | `error[E0432]: unresolved import `ort::ep::CUDAExecutionProvider`` |

rc.12 is the only one.

## The fix

Pin `ort` exactly, with a comment saying why, so the requirement matches what is verified:

```toml
ort = { version = "=2.0.0-rc.12", ... }
```

**This does not change the ONNX Runtime version.** The lockfile was already resolved to rc.12 and is untouched by this PR. All it does is stop downstream consumers from being silently resolved onto a version the crate cannot compile against.

## Second, separate install bug

Both README installation snippets said:

```toml
birdnet-onnx = "2.0"
```

Cargo never matches a pre-release from a plain caret requirement, and every 2.0.0 release so far is an rc, so that requirement selects nothing:

```
error: failed to select a version for the requirement `birdnet-onnx = "^2.0"`
candidate versions found which didn't match: 2.0.0-rc.15, 2.0.0-rc.14, ...
```

Both snippets now name the version in full.

## Verification

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --no-fail-fast`, 254 passed
- Fresh `cargo generate-lockfile` against the new requirement resolves `ort` to 2.0.0-rc.12, confirming the pin holds on a clean resolve
- The rc.11 / rc.12 / rc.13 table above was produced against the published 2.0.0-rc.15, so it reflects what users actually hit

## Note on reaching users

This fix only helps once a new release candidate is published. 2.0.0-rc.15 is the newest on crates.io and stays broken until then. The repo is already at 2.0.0-rc.16 and that version has not been published, so cutting rc.16 is enough; no extra version bump is needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed fresh-install compilation failures by pinning a compatible pre-release dependency version.
  * Corrected installation configuration to use full pre-release version numbers, ensuring Cargo resolves dependencies properly.

* **Documentation**
  * Updated installation instructions and dynamic linking examples with the required dependency version format.
  * Added clarification about specifying pre-release versions explicitly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->